### PR TITLE
Switch metadata over to our vendored version of this package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 package-lock.json
 docs
+.github_token

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "brackets-viewer",
-    "version": "1.6.2",
+    "name": "@ewanmellor/brackets-viewer",
+    "version": "1.6.903",
     "description": "A simple library to display tournament brackets (round-robin, single elimination, double elimination)",
     "files": [
         "dist/"
@@ -17,7 +17,10 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Drarig29/brackets-viewer.js.git"
+        "url": "git+https://github.com/ewanmellor/brackets-viewer.js.git"
+    },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com/"
     },
     "keywords": [
         "javascript",
@@ -26,7 +29,7 @@
         "viewer",
         "display"
     ],
-    "author": "Corentin Girard",
+    "author": "Corentin Girard with modifications by All Ball, LLC",
     "license": "ISC",
     "bugs": {
         "url": "https://github.com/Drarig29/brackets-viewer.js/issues"


### PR DESCRIPTION
Bump the version to 1.6.903, so it's always above upstream 1.6.x.