### PR TITLE
Add a noParticipantTitles config option.

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -296,11 +296,14 @@ export function createRankingHeaders(ranking: Ranking): HTMLElement {
  *
  * @param nameContainer The name container.
  * @param hint The hint to set.
+ * @param withoutTitle True to not add the title to the element (i.e. the
+ * browser-driven tooltip).
  */
-export function setupHint(nameContainer: HTMLElement, hint: string): void {
+export function setupHint(nameContainer: HTMLElement, hint: string, withoutTitle = false): void {
     nameContainer.classList.add('hint');
     nameContainer.innerText = hint;
-    nameContainer.title = hint;
+    if (!withoutTitle)
+        nameContainer.title = hint;
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,7 @@ export class BracketsViewer {
             highlightPlaceholdersOnHover: config?.highlightPlaceholdersOnHover ?? false,
             showRankingTable: config?.showRankingTable ?? true,
             getStyleForMatch: config?.getStyleForMatch,
+            noParticipantTitles: config?.noParticipantTitles,
         };
 
         if (config?.onMatchClick)
@@ -691,7 +692,8 @@ export class BracketsViewer {
 
         if (found) {
             containers.name.innerText = found.name;
-            containers.participant.setAttribute('title', found.name);
+            if (!this.config.noParticipantTitles)
+                containers.participant.setAttribute('title', found.name);
             this.renderParticipantImage(containers.name, found.id);
             this.renderParticipantOrigin(containers.name, participant, side, matchLocation, roundNumber);
         } else
@@ -800,7 +802,7 @@ export class BracketsViewer {
         if (!this.config.showSlotsOrigin) return;
         if (!this.config.showLowerBracketSlotsOrigin && matchLocation === 'loser_bracket') return;
 
-        dom.setupHint(nameContainer, originHint(participant.position));
+        dom.setupHint(nameContainer, originHint(participant.position), this.config.noParticipantTitles);
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,13 @@ export interface Config {
      * Whether to clear any previously displayed data.
      */
     clear?: boolean
+
+    /**
+     * True to not add the title to the participant elements (i.e. the
+     * browser-driven tooltips).  This applies to both the real and
+     * the placeholder (hint) participant display.
+     */
+    noParticipantTitles?: boolean
 }
 
 /**


### PR DESCRIPTION
This allows the caller to disable titles (i.e. the browser-driven tooltips) on the participants elements (both real and hint).